### PR TITLE
Move existing typing-related dependencies to 'dev' dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,16 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.8"
 cachetools = "^5.2.0"
-mypy = "^0.982"
-types-cachetools = "^5.2.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.10.0"
+mypy = "^0.982"
 pytest = "^7.1.3"
 isort = "^5.10.1"
 pylint = "^2.15.3"
 Sphinx = "^5.3.0"
 sphinx-rtd-theme = "^1.0.0"
+types-cachetools = "^5.2.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Fixes #12

I don't know if you accept PRs (your codebase is small enough and stable enough that it doesn't really warrant a contributor policy, which is a compliment!), but figured I'd maybe save you a couple minutes of work.

This may not be the "best' fix (I suspect _maybe_ a minimum bound, if that), but it was "simple" and is working for me.  (To unblock myself, I'm doing a VCS-based install of my fork/branch.)

You're welcome to accept this, ignore it, or plagiarize it as you see fit.  Being able to install from pypi (rather than my fork) is all I really care about.