### PR TITLE
await pending future

### DIFF
--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -93,7 +93,6 @@ class SyncMixin:
 
     def test_decorator_lock(self):
         class Lock(object):
-
             count = 0
 
             def __enter__(self):
@@ -194,7 +193,6 @@ class AsyncMixin:
     @sync
     async def test_decorator_lock_async(self):
         class Lock(object):
-
             count = 0
 
             async def __aenter__(self):
@@ -209,11 +207,11 @@ class AsyncMixin:
         self.assertEqual(len(cache), 0)
         self.assertEqual(wrapper.__wrapped__, self.coro)
         self.assertEqual((await wrapper(0)), 0)
+        self.assertEqual(Lock.count, 1)
+        self.assertEqual((await wrapper(1)), 1)
         self.assertEqual(Lock.count, 2)
         self.assertEqual((await wrapper(1)), 1)
-        self.assertEqual(Lock.count, 4)
-        self.assertEqual((await wrapper(1)), 1)
-        self.assertEqual(Lock.count, 5)
+        self.assertEqual(Lock.count, 3)
 
 
 class DictWrapperTest(unittest.TestCase, SyncMixin, AsyncMixin):


### PR DESCRIPTION
It's a possible solution for https://github.com/hephex/asyncache/issues/2

When invoking the same cached func multiple times, if the future returned by the first call is still pending then wait for it instead of triggering a new call.

Note: do not cache errors. When the call fails, the future is removed from the cache.

Note 2: this behaviours should be customizable (ie. error handling, multiple calls, etc.)
